### PR TITLE
pxr, sdl: drop now invalid :unneeded

### DIFF
--- a/pxr.rb
+++ b/pxr.rb
@@ -3,7 +3,6 @@ class Pxr < Formula
   desc ""
   homepage ""
   version "0.0.1"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/metrumresearchgroup/pxr/releases/download/0.0.1/pxr_0.0.1_darwin_amd64.tar.gz"

--- a/sdl.rb
+++ b/sdl.rb
@@ -3,7 +3,6 @@ class Sdl < Formula
   desc ""
   homepage ""
   version "0.1.2"
-  bottle :unneeded
 
   if OS.mac?
     url "https://github.com/metrumresearchgroup/sdl/releases/download/v0.1.2/sdl_0.1.2_Darwin_x86_64.tar.gz"


### PR DESCRIPTION
Homebrew started warning about :unneeded a while ago, and trying to
initialize a tap now fails:

    $ brew --version
    Homebrew 3.4.0
    Homebrew/homebrew-core (git revision 53651c46ae9; last commit 2022-03-04)
    Homebrew/homebrew-cask (git revision fe09f6227a; last commit 2022-03-04)

    $ brew tap metrumresearchgroup/tap
    [...]
    Error: Invalid formula: /usr/local/Homebrew/Library/Taps/metrumresearchgroup/homebrew-tap/sdl.rb
    sdl: Calling bottle :unneeded is disabled! There is no replacement.
    Please report this issue to the metrumresearchgroup/tap tap (not Homebrew/brew or Homebrew/core):
      /usr/local/Homebrew/Library/Taps/metrumresearchgroup/homebrew-tap/sdl.rb:6

    Error: Invalid formula: /usr/local/Homebrew/Library/Taps/metrumresearchgroup/homebrew-tap/pxr.rb
    pxr: Calling bottle :unneeded is disabled! There is no replacement.
    Please report this issue to the metrumresearchgroup/tap tap (not Homebrew/brew or Homebrew/core):
      /usr/local/Homebrew/Library/Taps/metrumresearchgroup/homebrew-tap/pxr.rb:6

    Error: Cannot tap metrumresearchgroup/tap: invalid syntax in tap!

These two files were auto-generated by goreleaser.  Newer versions of
goreleaser do not add `:unneeded` (see goreleaser pr 2591), so going
forward updates should not include :unneeded (see, e.g., the recent
bbi.rb and pkgr.rb updates).

However, these two packages may not get a new release anytime soon.
Manually drop :unneeded from these files to avoid the above error.